### PR TITLE
Fixed compatibility with recent Koa versions. Also, fixed flash message support.

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -36,14 +36,22 @@ function initialize(passport) {
 function authenticate(passport, name, options, callback) {
   var middleware = _authenticate(passport, name, options, callback)
   return function*(next) {
-    // koa ↔ connect compatibility
-    this.req.session = this.session
-    this.req.query = this.query
     var ctx = this
 
     // this functions wraps the connect middleware
     // to catch `next`, `res.redirect` and `res.end` calls
     var cont = yield function(done) {
+      // koa ↔ connect compatibility
+      var req = ctx.req
+      req.query = ctx.request.query
+      req.body = ctx.request.body
+      req.session = ctx.session
+      req.flash = function flash(name, value) { // emulate connect-flash
+        var o = {};
+        o[name] = value;
+        ctx.flash = o;
+      };
+
       // mock the `res` object
       var res = {
         redirect: function(url) {
@@ -64,7 +72,7 @@ function authenticate(passport, name, options, callback) {
       }
 
       // call the connect middleware
-      middleware(this.req, res, done)
+      middleware(req, res, done)
     }
 
     // cont equals `false` when `res.redirect` or `res.end` got called


### PR DESCRIPTION
- Make compatible with latest Koa versions (separate .req and .request).
- Add compatibility with koa-flash by emulating connect-flash (for Passport options like failureFlash).
