### PR TITLE
Binds functions on request instead of req

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ app.use(passport.initialize())
 app.use(passport.session())
 ```
 
+
+## Function mapping
+
+You can use passport functions on the ctx object directly. The user is available on the request object and not req, because in Koa req is the raw node request object.
+
+```js
+app.use(function *() {
+  var user = this.request.user
+
+  // isAuth
+  if(this.isAuthenticated())
+
+  // login
+  this.login(/*...*/)
+  this.logIn(/*...*/)
+
+  // same thing for logout, isUnauthenticated
+})
+
+```
+
 [Example Application](https://github.com/rkusa/koa-passport-example)
 
 ## MIT License

--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -20,9 +20,7 @@ function initialize(passport) {
   var middleware = _initialize(passport)
   return function* passportInitialize(next) {
     // koa <-> connect compatibility
-    this.req.session = this.session
-    this.req.query = this.request.query
-    this.req.body = this.request.body
+    this.request.session = this.session
 
     // add aliases for passport's request extensions to `ctx`
     var ctx = this
@@ -31,11 +29,12 @@ function initialize(passport) {
         ctx.req.login(user, options, done)
       }
     }
-    ctx.logout = ctx.logOut = ctx.req.logout.bind(ctx.req)
-    ctx.isAuthenticated = ctx.req.isAuthenticated.bind(ctx.req)
-    ctx.isUnauthenticated = ctx.req.isUnauthenticated.bind(ctx.req)
+    ctx.request.login = ctx.request.logIn = ctx.req.login.bind(ctx.request)
+    ctx.logout = ctx.logOut = ctx.request.logout = ctx.req.logout.bind(ctx.request)
+    ctx.isAuthenticated = ctx.request.isAuthenticated = ctx.req.isAuthenticated.bind(ctx.request)
+    ctx.isUnauthenticated = ctx.request.isUnauthenticated = ctx.req.isUnauthenticated.bind(ctx.request)
 
-    yield middleware.bind(middleware, this.req, this)
+    yield middleware.bind(middleware, this.request, this)
     yield next
   }
 }
@@ -106,9 +105,8 @@ function authenticate(passport, name, options, callback) {
       if (callback) {
         callback.done = done
       }
-
       // call the connect middleware
-      middleware(ctx.req, res, done)
+      middleware(ctx.request, res, done)
     }
 
     // cont equals `false` when `res.redirect` or `res.end` got called


### PR DESCRIPTION
Hi! 

I'm trying to retrieve certain fields that are only available on the koa ctx.request object in the `passport.authenticate` function of my Strategy. The problem is that the object passed by the middleware is the raw node request object instead of the koa request object 

```
 middleware(ctx.req, res, done) 
```

https://github.com/rkusa/koa-passport/blob/master/lib/framework/koa.js#L111

Is there a way to work around that?

One way would be to bind everything on the ctx.request object instead of ctx.req. But it would change what users are used to... So like instead of `ctx.req.user` to retrieve user it would be `ctx.request.user` and so on.

This way it's way easier to interact with special function of request like host/protocol/charset/etc.
