### PR TITLE
base request mock on Koa Request object

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -154,7 +154,6 @@ module.exports = function() {
 // create request mock
 var properties = require('./request')
 function createReqMock(ctx) {
-  var req = Object.create(ctx.req, properties)
-  req.context = ctx
+  var req = Object.create(ctx.request, properties)
   return req
 }

--- a/lib/framework/request.js
+++ b/lib/framework/request.js
@@ -70,6 +70,7 @@ var keys = [
   'toJSON',
   'originalUrl',
   'accept',
+  'connection',
 
   // Koa's context
   'app',
@@ -96,7 +97,7 @@ var properties = module.exports = {}
 keys.forEach(function(key) {
   properties[key] = {
     get: function() {
-      var obj = getObject(this.context, key)
+      var obj = getObject(this.ctx, key)
       if (!obj) return undefined
 
       // if its a function, call with the proper context
@@ -110,7 +111,7 @@ keys.forEach(function(key) {
       return obj[key]
     },
     set: function(value) {
-      var obj = getObject(this.context, key) || this.context.passport
+      var obj = getObject(this.ctx, key) || this.ctx.passport
       obj[key] = value
     }
   }


### PR DESCRIPTION
By Koa convention, node `req` should be virgin.
We only modify `request`.

As a bonus, no need to assign `.context` explicitly.
