### PR TITLE
make sure `ctx.passport` isn't undefined before using `in` operator

### DIFF
--- a/lib/framework/request.js
+++ b/lib/framework/request.js
@@ -115,7 +115,7 @@ keys.forEach(function(key) {
 // test where the key is available, either in `ctx.passport`, Node's request,
 // Koa's request or Koa's context
 function getObject(ctx, key) {
-  if (key in ctx.passport) {
+  if (ctx.passport && (key in ctx.passport)) {
     return ctx.passport
   }
 


### PR DESCRIPTION
Within function `getObject`, if `ctx.passport` is undefined, there will throw a `[TypeError:  Cannot use 'in' operator to search for 'body' in undefined]`.
