### PR TITLE
authenticate callback error handling fixed

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -86,8 +86,12 @@ function authenticate(passport, name, options, callback) {
     // to inform `passportAuthenticate()` that we are ready.
     var _callback = callback
     callback = co.wrap(function*(err, user, info, status) {
-      yield _callback(err, user, info, status)
-      callback.done(null, false)
+      try {
+        yield _callback(err, user, info, status)
+        callback.done(null, false)
+      } catch (err) {
+        callback.done(err);
+      }
     })
   }
 


### PR DESCRIPTION
This pull request solves the stuck of the authenticate callback method when an error is thrown inside this callback.

Example for reproduction:

```js
auth.post('/login', function* (next) {
	yield passport.authenticate(strategy, function* (err, user) {
		throw new Error('Getting stuck');
	}).call(this, next);
});
```