### PR TITLE
Export the KoaPassport constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,17 @@
-var passport = module.exports = require('passport')
+var passport = require('passport')
+var Passport = require('passport').Passport
+var framework = require('./framework/koa')()
 
-passport.framework(require('./framework/koa')())
+passport.framework(framework)
+
+var KoaPassport = function () {
+  Passport.call(this)
+  this.framework(framework)
+}
+require('util').inherits(KoaPassport, Passport)
+
+// Export default singleton.
+module.exports = passport
+
+// Expose constructor
+module.exports.KoaPassport = KoaPassport


### PR DESCRIPTION
This allows apps to avoid using a Passport singleton
The same pattern is followed in the Passport repo.
https://github.com/jaredhanson/passport/blob/33075756a626999c6e2efc872b055e45ae434053/lib/index.js#L18