### PR TITLE
Fix invalid super call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ passport.framework(framework)
 
 class KoaPassport extends Passport {
   constructor() {
-    super(this)
+    super()
     this.framework(framework)
   }
 }


### PR DESCRIPTION
`super(this)` is invalid and throws an error.
Removing `this` fixes it.