### PR TITLE
Adding ctx.state.user support

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 const passport = require('passport')
+const deprecate = require('depd')('koa-passport')
 
 /**
  * Passport's default/connect middleware.
@@ -28,9 +29,11 @@ function initialize(passport) {
       Object.defineProperty(ctx.req, userProperty, {
         enumerable: true,
         get: function() {
+          deprecate('getting ctx.req.' + userProperty + ' is deprecated in favour of ctx.state.' + userProperty)
           return ctx.passport[userProperty]
         },
         set: function(val) {
+          deprecate('setting ctx.req.' + userProperty + ' is deprecated in favour of ctx.state.' + userProperty)
           ctx.passport[userProperty] = val
         }
       })
@@ -134,6 +137,13 @@ function authenticate(passport, name, options, callback) {
 
       // call the connect middleware
       middleware(req, res).then(resolve, reject)
+
+      // store authenticated user in ctx.state
+      // ctx.state.user is exposed to downstream middleware
+      .then(() => {
+        const userProperty = passport._userProperty || 'user'
+        ctx.state[userProperty] = ctx.passport[userProperty]
+      })
     })
 
     // cont equals `false` when `res.redirect` or `res.end` got called

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "./lib",
   "dependencies": {
+    "depd": "^1.1.0",
     "passport": "^0.3.0"
   },
   "devDependencies": {

--- a/test/authenticate.js
+++ b/test/authenticate.js
@@ -90,6 +90,7 @@ describe('authenticate middleware', function() {
     .expect(204)
     .then(() => {
       expect(context.req.user).to.be.undefined
+      expect(context.state.user).to.be.undefined
     })
   })
 
@@ -105,6 +106,7 @@ describe('authenticate middleware', function() {
         expect(session).to.eql({})
         expect(context.isAuthenticated()).to.be.false
         expect(context.isUnauthenticated()).to.be.true
+        expect(context.state.user).to.be.undefined
         expect()
       })
     })
@@ -119,6 +121,7 @@ describe('authenticate middleware', function() {
         expect(redirectTo).to.equal('/secured')
         expect(context.isAuthenticated()).to.be.true
         expect(context.isUnauthenticated()).to.be.false
+        expect(context.state.user).to.eql(user)
         expect(session).to.eql({
           passport: { user: 1 }
         })
@@ -138,6 +141,7 @@ describe('authenticate middleware', function() {
           })
           expect(context.isAuthenticated()).to.be.true
           expect(context.isUnauthenticated()).to.be.false
+          expect(context.state.user).to.eql(user)
         })
       })
     })
@@ -151,6 +155,7 @@ describe('authenticate middleware', function() {
         expect(session).to.eql({ passport: {} })
         expect(context.isAuthenticated()).to.be.false
         expect(context.isUnauthenticated()).to.be.true
+        expect(context.state.user).to.be.undefined
       })
     })
   })
@@ -165,6 +170,7 @@ describe('authenticate middleware', function() {
         expect(session).to.eql({})
         expect(context.isAuthenticated()).to.be.false
         expect(context.isUnauthenticated()).to.be.true
+        expect(context.state.user).to.be.undefined
         expect()
       })
     })
@@ -177,6 +183,7 @@ describe('authenticate middleware', function() {
       .then(() => {
         expect(context.isAuthenticated()).to.be.true
         expect(context.isUnauthenticated()).to.be.false
+        expect(context.state.user).to.eql(user)
         expect(session).to.eql({
           passport: { user: 1 }
         })


### PR DESCRIPTION
Addresses #57 
 - Expose the authenticated user via `ctx.state.user`.
 - Add deprecation warning when accessing `ctx.req.user`
 - Updated unit tests

This conforms to Koa v2 best practices for passing data through the middleware stack, https://github.com/koajs/koa/blob/v2.x/docs/api/context.md#ctxstate

Note: `npm install` to grab new dependency