### PR TITLE
Refactor async control flow to prevent race condition

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -137,18 +137,16 @@ function authenticate(passport, name, options, callback) {
 
       // call the connect middleware
       middleware(req, res).then(resolve, reject)
-
-      // store authenticated user in ctx.state
-      // ctx.state.user is exposed to downstream middleware
-      .then(() => {
-        const userProperty = passport._userProperty || 'user'
-        ctx.state[userProperty] = ctx.passport[userProperty]
-      })
     })
 
-    // cont equals `false` when `res.redirect` or `res.end` got called
-    // in this case, call next to continue through Koa's middleware stack
     return p.then(cont => {
+      // store authenticated user in ctx.state
+      // ctx.state.user is exposed to downstream middleware
+      const userProperty = passport._userProperty || 'user'
+      ctx.state[userProperty] = ctx.passport[userProperty]
+
+      // cont equals `false` when `res.redirect` or `res.end` got called
+      // in this case, call next to continue through Koa's middleware stack
       if (cont !== false) {
         return next()
       }


### PR DESCRIPTION
Refactor async control flow to prevent race condition
Related to #57 

Previously, `next()` could be called before `ctx.state.user` is assigned because `resolve` callback is invoked first which resolves `p`. This also happens in the case when a callback is passed