### PR TITLE
Properly support options.assignProperty in authenticate middleware

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -37,7 +37,7 @@ function initialize(passport) {
     }
 
     // create mock object for express' req object
-    const req = createReqMock(ctx)
+    const req = createReqMock(ctx, userProperty)
 
 
     // add Promise-based login method
@@ -106,7 +106,7 @@ function authenticate(passport, name, options, callback) {
     // to catch `next`, `res.redirect` and `res.end` calls
     const p = new Promise((resolve, reject) => {
       // mock the `req` object
-      const req = createReqMock(ctx)
+      const req = createReqMock(ctx, options.assignProperty || passport._userProperty || 'user')
 
       // mock the `res` object
       const res = {

--- a/lib/framework/request.js
+++ b/lib/framework/request.js
@@ -31,8 +31,6 @@
 let keys = [
   // passport
   '_passport',
-  'user',
-  'account',
   'authInfo',
 
   // http.IncomingMessage
@@ -133,8 +131,18 @@ function getObject(ctx, key) {
 
 const IncomingMessageExt = require('passport/lib/http/request')
 
-exports.create = function(ctx) {
+exports.create = function(ctx, userProperty) {
   const req = Object.create(ctx.request, properties)
+
+  Object.defineProperty(req, userProperty, {
+    enumerable: true,
+    get: function() {
+      return ctx.state[userProperty]
+    },
+    set: function(val) {
+      ctx.state[userProperty] = val
+    }
+  })
 
   // add passport http.IncomingMessage extensions
   req.login = IncomingMessageExt.logIn


### PR DESCRIPTION
In passport's built in session middleware, it looks to `passport._userProperty` to determine what property to set the deserialized user on `req`. Currently, the mocked `req` object only proxies the default `user` and `account` properties. The property also doesn't show up on `ctx.state` after calling `req.login`.

This simply adjusts the signature of the function for creating a mock `req` object to accept the name of the user property to define the appropriate setters and getters for.