### PR TITLE
change setHeader to match expressjs api

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -119,7 +119,7 @@ function authenticate(passport, name, options, callback) {
           ctx.redirect(url)
           resolve(false)
         },
-        setHeader: ctx.set.bind(ctx),
+        set: ctx.set.bind(ctx),
         end: setBodyAndResolve,
         send: setBodyAndResolve,
         set statusCode(status) {

--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -120,6 +120,7 @@ function authenticate(passport, name, options, callback) {
           resolve(false)
         },
         set: ctx.set.bind(ctx),
+        setHeader: ctx.set.bind(ctx),
         end: setBodyAndResolve,
         send: setBodyAndResolve,
         set statusCode(status) {


### PR DESCRIPTION
I tried to find where setHeader is in the api, it seems like the correct method is `set`. Fixes an issue with this passport strategy:

https://github.com/auth0/passport-wsfed-saml2/blob/cc8d85e2dba45218e6d6afed9948c577f3669503/lib/passport-wsfed-saml2/strategy.js#L256