### PR TITLE
fix: Add missing "ip" to request proxy object

### DIFF
--- a/lib/framework/request.js
+++ b/lib/framework/request.js
@@ -48,6 +48,7 @@ let keys = [
   // Koa's context
   'cookies',
   'throw',
+  'ip',
 
   // Others. Are not supported directly - require proper plugins/middlewares.
   'param',
@@ -57,8 +58,7 @@ let keys = [
   'baseUrl',
   'session',
   'body',
-  'flash',
-  'ip'
+  'flash'
 ]
 
 // remove duplicates

--- a/lib/framework/request.js
+++ b/lib/framework/request.js
@@ -57,7 +57,8 @@ let keys = [
   'baseUrl',
   'session',
   'body',
-  'flash'
+  'flash',
+  'ip'
 ]
 
 // remove duplicates


### PR DESCRIPTION
Attempting to access `req.ip` inside of the passport callback is not currently possible when using `koa-passport`