### PR TITLE
Add async logout(options) method

### DIFF
--- a/lib/framework/koa.js
+++ b/lib/framework/koa.js
@@ -51,8 +51,18 @@ function initialize(passport) {
       })
     }
 
+    // add Promise-based logout method
+    const logout  = req.logout
+    ctx.logout = ctx.logOut = function(options) {
+      return new Promise((resolve, reject) => {
+        logout.call(req, options, err => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+    }
+
     // add aliases for passport's request extensions to Koa's context
-    ctx.logout = ctx.logOut = req.logout.bind(req)
     ctx.isAuthenticated     = req.isAuthenticated.bind(req)
     ctx.isUnauthenticated   = req.isUnauthenticated.bind(req)
 


### PR DESCRIPTION
Passport v0.6.0 added new `options` and `callback` arguments to `req.logout(options, callback)`.  
`ctx.logout()` should thus become `async` and use this callback. 